### PR TITLE
Add SidekiqKeywordArguements cop

### DIFF
--- a/lib/rubocop/cop/netlify/sidekiq_keyword_arguments.rb
+++ b/lib/rubocop/cop/netlify/sidekiq_keyword_arguments.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Netlify
+      # This cop checks the usage of keyword arguments in Sidekiq workers.
+      #
+      # @example
+      #   # bad
+      #   def perform(user_id, name:)
+      #
+      #   # good
+      #   def perform(user_id, name)
+      class SidekiqKeywordArguments < Cop
+        MSG = "Avoid keyword arguments in workers"
+        OBSERVED_METHOD = :perform
+
+        def on_def(node)
+          return if node.method_name != OBSERVED_METHOD
+
+          node.arguments.each do |argument|
+            if keyword_argument?(argument)
+              add_offense(node, location: :expression)
+              break
+            end
+          end
+        end
+
+        private
+
+        def keyword_argument?(argument)
+          argument.type == :kwarg || argument.type == :kwoptarg
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/netlify_cops.rb
+++ b/lib/rubocop/cop/netlify_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative "netlify/request_tests_param_encoding"
+require_relative "netlify/sidekiq_keyword_arguments"

--- a/test/rubocop/cop/netlify/sidekiq_keyword_arguments_test.rb
+++ b/test/rubocop/cop/netlify/sidekiq_keyword_arguments_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class SidekiqKeywordArgumentsTest < Minitest::Test
+  def test_offense_with_only_keyword_arguments
+    assert_offense <<~RUBY
+      class Worker
+        def perform(user_id:, update: true)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid keyword arguments in workers
+          puts user_id
+        end
+      end
+    RUBY
+  end
+
+  def test_offense_with_trailing_keyword_arguments
+    assert_offense <<~RUBY
+      class Worker
+        def perform(user_id, update:, name:)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid keyword arguments in workers
+          puts user_id
+        end
+      end
+    RUBY
+  end
+
+  def test_offense_with_keyword_arguments_defaults
+    assert_offense <<~RUBY
+      class Worker
+        def perform(user_id, update: true)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid keyword arguments in workers
+          puts user_id
+        end
+      end
+    RUBY
+  end
+
+  def test_no_offense_with_regular_arguments
+    assert_no_offenses <<~RUBY
+      class Worker
+        def perform(user_id, update = {})
+          puts user_id
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
This is so we avoid adding keyword arguments to Sidekiq workers. Well, technically anywhere, but we should add this only to `app/workers`.

We had a few of this issues in the past and it's easy to forget when reviewing a PR.