### PR TITLE
GH-8038 New cop for attribute assignment

### DIFF
--- a/lib/rubocop/cop/netlify/invalid_model_assignment.rb
+++ b/lib/rubocop/cop/netlify/invalid_model_assignment.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Netlify
+      # This cop checks attribute assignment of Mongoid models
+      #
+      # @example
+      #   # bad
+      #   form.attributes[:email] = "bettse@netlify.com"
+      #
+      #   # good
+      #   form.email = "bettse@netlify.com"
+      class InvalidModelAssignment < Cop
+        MSG = "Assigning to `attributes` will not update record"
+        OBSERVED_METHOD = :attributes
+
+        def on_def(node)
+          return if node.method_name != OBSERVED_METHOD
+
+          node.arguments.each do |argument|
+            if keyword_argument?(argument)
+              add_offense(node, location: :expression)
+              break
+            end
+          end
+        end
+
+        def on_send(node)
+          if node.assign_attributes?
+            add_offense(node, message: MSG)
+          end
+        end
+
+        private
+
+        def_node_matcher :assign_attributes?, <<~PATTERN
+          (send (send (...) :attributes) :[]= _ _)
+        PATTERN
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/netlify/invalid_model_assignment.rb
+++ b/lib/rubocop/cop/netlify/invalid_model_assignment.rb
@@ -13,18 +13,6 @@ module RuboCop
       #   form.email = "bettse@netlify.com"
       class InvalidModelAssignment < Cop
         MSG = "Assigning to `attributes` will not update record"
-        OBSERVED_METHOD = :attributes
-
-        def on_def(node)
-          return if node.method_name != OBSERVED_METHOD
-
-          node.arguments.each do |argument|
-            if keyword_argument?(argument)
-              add_offense(node, location: :expression)
-              break
-            end
-          end
-        end
 
         def on_send(node)
           if node.assign_attributes?

--- a/lib/rubocop/cop/netlify/invalid_model_assignment.rb
+++ b/lib/rubocop/cop/netlify/invalid_model_assignment.rb
@@ -13,18 +13,15 @@ module RuboCop
       #   form.email = "bettse@netlify.com"
       class InvalidModelAssignment < Cop
         MSG = "Assigning to `attributes` will not update record"
-
-        def on_send(node)
-          if node.assign_attributes?
-            add_offense(node, message: MSG)
-          end
-        end
-
-        private
+        RESTRICT_ON_SEND = [:attributes].freeze
 
         def_node_matcher :assign_attributes?, <<~PATTERN
           (send (send (...) :attributes) :[]= _ _)
         PATTERN
+
+        def on_send(node)
+          add_offense(node) if assign_attributes? node
+        end
       end
     end
   end

--- a/lib/rubocop/cop/netlify_cops.rb
+++ b/lib/rubocop/cop/netlify_cops.rb
@@ -2,3 +2,4 @@
 
 require_relative "netlify/request_tests_param_encoding"
 require_relative "netlify/sidekiq_keyword_arguments"
+require_relative "netlify/invalid_model_assignment"

--- a/test/rubocop/cop/netlify/invalid_model_assignment_test.rb
+++ b/test/rubocop/cop/netlify/invalid_model_assignment_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class InvalidModelAssignmentTest < Minitest::Test
+  def test_offense_with_model_assignment
+    assert_offense <<~RUBY
+      class User
+        attr_reader :attributes
+      end
+      user = User.new
+      user.attributes[:email] = \"test@example.com\"
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assigning to `attributes` will not update record
+    RUBY
+  end
+
+  def test_does_not_registers_offense_reading
+    assert_no_offenses <<~RUBY
+      class User
+        attr_reader :attributes
+      end
+      user = User.new
+      puts user.attributes
+    RUBY
+  end
+
+  def test_does_not_registers_offense_with_variable
+    assert_no_offenses <<~RUBY
+      attributes = {}
+      attributes[:email] = "test@example.com"
+      puts attributes
+    RUBY
+  end
+end

--- a/test/rubocop/cop/netlify/invalid_model_assignment_test.rb
+++ b/test/rubocop/cop/netlify/invalid_model_assignment_test.rb
@@ -9,7 +9,7 @@ class InvalidModelAssignmentTest < Minitest::Test
         attr_reader :attributes
       end
       user = User.new
-      user.attributes[:email] = \"test@example.com\"
+      user.attributes[:email] = "test@example.com"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assigning to `attributes` will not update record
     RUBY
   end


### PR DESCRIPTION
https://github.com/netlify/bitballoon/issues/8038

Prevent assigning to attributes by key.  With Mongoid models this doesn't register as `changed?`, so `save` doesn't update the record.  This cop matches more than just Mongoid documents, but only as a property and still allows "attributes" to be used as a variable name.