### PR TITLE
Update rubocop dependency to < 2.0

### DIFF
--- a/lib/rubocop/cop/netlify/invalid_model_assignment.rb
+++ b/lib/rubocop/cop/netlify/invalid_model_assignment.rb
@@ -13,7 +13,6 @@ module RuboCop
       #   form.email = "bettse@netlify.com"
       class InvalidModelAssignment < Cop
         MSG = "Assigning to `attributes` will not update record"
-        RESTRICT_ON_SEND = [:attributes].freeze
 
         def_node_matcher :assign_attributes?, <<~PATTERN
           (send (send (...) :attributes) :[]= _ _)

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.85", "< 0.87"
+  spec.add_dependency "rubocop", "~> 0.87", "< 0.88"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.72", "< 0.83"
+  spec.add_dependency "rubocop", "~> 0.72", "< 0.84"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.72", "< 0.84"
+  spec.add_dependency "rubocop", "~> 0.85", "< 0.86"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.87", "< 0.90"
+  spec.add_dependency "rubocop", "~> 0.72", "< 0.90"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.72", "< 0.91"
+  spec.add_dependency "rubocop", "~> 0.72", "< 1.0"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.72", "< 0.90"
+  spec.add_dependency "rubocop", "~> 0.72", "< 0.91"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.72", "< 1.0"
+  spec.add_dependency "rubocop", "~> 0.72", "< 2.0"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.87", "< 0.88"
+  spec.add_dependency "rubocop", "~> 0.87", "< 0.89"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.87", "< 0.89"
+  spec.add_dependency "rubocop", "~> 0.87", "< 0.90"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.85", "< 0.86"
+  spec.add_dependency "rubocop", "~> 0.85", "< 0.87"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/test/assertion_helper.rb
+++ b/test/assertion_helper.rb
@@ -3,7 +3,6 @@
 # Copied and adapted from:
 # https://github.com/rubocop-hq/rubocop-minitest/blob/v0.8.1/test/assertion_helper.rb
 #
-#
 # ===========
 #
 #
@@ -70,10 +69,10 @@ module AssertionHelper
   end
 
   def investigate(cop, processed_source)
-    forces = RuboCop::Cop::Force.all.each_with_object([]) do |klass, instances|
-      next unless cop.join_force?(klass)
-
-      instances << klass.new([cop])
+    needed = Hash.new { |h, k| h[k] = [] }
+    Array(cop.class.joining_forces).each { |force| needed[force] << cop }
+    forces = needed.map do |force_class, joining_cops|
+      force_class.new(joining_cops)
     end
 
     commissioner = RuboCop::Cop::Commissioner.new([cop], forces, raise_error: true)


### PR DESCRIPTION
First part of updating the required version of rubocop to unblock upgrades in applications that use this gem. This goes up to 0.89 before having to get into bigger changes.

I required some changes in custom assertions code when going to 0.87 so now tests will have to be run with latest version. It doesn't affect the cops, so it's safe to bump.

~More updates to come in separate PRs.~

Update: Merged https://github.com/netlify/rubocop-netlify/pull/9. Now it supports up to < 2.0
One thing changed when updating to 0.90, we were using `RESTRICT_ON_SEND` in an unintended way and before 0.90 it was ignored. See rubocop/rubocop#8365

