### PR TITLE
Update dependencies to rubocop < 2

### DIFF
--- a/lib/rubocop/cop/netlify/invalid_model_assignment.rb
+++ b/lib/rubocop/cop/netlify/invalid_model_assignment.rb
@@ -13,7 +13,6 @@ module RuboCop
       #   form.email = "bettse@netlify.com"
       class InvalidModelAssignment < Cop
         MSG = "Assigning to `attributes` will not update record"
-        RESTRICT_ON_SEND = [:attributes].freeze
 
         def_node_matcher :assign_attributes?, <<~PATTERN
           (send (send (...) :attributes) :[]= _ _)

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.72", "< 0.91"
+  spec.add_dependency "rubocop", "~> 0.72", "< 1.0"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.72", "< 0.90"
+  spec.add_dependency "rubocop", "~> 0.72", "< 0.91"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.72", "< 1.0"
+  spec.add_dependency "rubocop", "~> 0.72", "< 2.0"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
Followup to https://github.com/netlify/rubocop-netlify/pull/8

One thing changed when updating to 0.90, we were using `RESTRICT_ON_SEND` in an unintended way and before 0.90 it was ignored. See https://github.com/rubocop-hq/rubocop/pull/8365