### PR TITLE
Pass the strategy option to fossa

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -31,6 +31,6 @@ jobs:
           sed -i "${line_number}s|.*|  project: git@github.com:${GITHUB_REPOSITORY}.git|" .fossa.yml
           cat .fossa.yml
       - name: Upload dependencies
-        run: fossa analyze --debug
+        run: fossa analyze --debug --option strategy:list
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
Since rubocop-netlify doesn't have `Gemfile.lock` file, the default fossa setup fails. It should work fine by specifying the strategy option as list, let's see how it goes.

https://github.com/fossas/fossa-cli/blob/master/docs/integrations/ruby.md#strategy-string