### PR TITLE
Allow anything above 0.72

### DIFF
--- a/lib/rubocop/netlify/version.rb
+++ b/lib/rubocop/netlify/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Netlify
-    VERSION = "0.4.0"
+    VERSION = "0.5.0"
   end
 end

--- a/rubocop-netlify.gemspec
+++ b/rubocop-netlify.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
-  spec.add_dependency "rubocop", "~> 0.72", "< 2.0"
+  spec.add_dependency "rubocop", ">= 0.72", "< 2.0"
   spec.add_development_dependency "minitest", "~> 5.10"
 
   # Specify which files should be added to the gem when it is released.


### PR DESCRIPTION
I'm not sure what I'm doing but I _think_ the current one is not allowing the 1.x version of rubocop so let's try this.