### PR TITLE
Cop to prevent checking env through Rails.env

### DIFF
--- a/lib/rubocop/cop/netlify/rails_env_check.rb
+++ b/lib/rubocop/cop/netlify/rails_env_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
     module Cop
       module Netlify

--- a/lib/rubocop/cop/netlify/rails_env_check.rb
+++ b/lib/rubocop/cop/netlify/rails_env_check.rb
@@ -1,0 +1,25 @@
+module RuboCop
+    module Cop
+      module Netlify
+        # This cop checks for use of Rails.env to check the environment
+        #
+        # @example
+        #   # bad
+        #   Rails.env.production?
+        #
+        #   # good
+        #   Netlify.env.production?
+        class RailsEnvCheck < Cop
+          MSG = "Prefer using `Netlify.env`` instead of `Rails.env` to check the environment"
+
+          def_node_matcher :rails_env?, <<~PATTERN
+            (send (send (const {nil? cbase} :Rails) :env) /staging?|production?/)
+          PATTERN
+
+          def on_send(node)
+            add_offense(node) if rails_env? node
+          end
+        end
+      end
+    end
+  end

--- a/lib/rubocop/cop/netlify/rails_env_check.rb
+++ b/lib/rubocop/cop/netlify/rails_env_check.rb
@@ -10,7 +10,7 @@ module RuboCop
         #   # good
         #   Netlify.env.production?
         class RailsEnvCheck < Cop
-          MSG = "Prefer using `Netlify.env`` instead of `Rails.env` to check the environment"
+          MSG = "Prefer using `Netlify.env` instead of `Rails.env` to check the environment"
 
           def_node_matcher :rails_env?, <<~PATTERN
             (send (send (const {nil? cbase} :Rails) :env) /staging?|production?/)

--- a/lib/rubocop/cop/netlify_cops.rb
+++ b/lib/rubocop/cop/netlify_cops.rb
@@ -3,3 +3,4 @@
 require_relative "netlify/request_tests_param_encoding"
 require_relative "netlify/sidekiq_keyword_arguments"
 require_relative "netlify/invalid_model_assignment"
+require_relative "netlify/rails_env_check"

--- a/test/rubocop/cop/netlify/rails_env_check_test.rb
+++ b/test/rubocop/cop/netlify/rails_env_check_test.rb
@@ -6,14 +6,14 @@ class RailsEnvCheckTest < Minitest::Test
   def test_offense_with_rails_production
     assert_offense <<~RUBY
       if Rails.env.production?; end
-         ^^^^^^^^^^^^^^^^^^^^^ Prefer using `Netlify.env`` instead of `Rails.env` to check the environment
+         ^^^^^^^^^^^^^^^^^^^^^ Prefer using `Netlify.env` instead of `Rails.env` to check the environment
     RUBY
   end
 
   def test_offense_with_rails_staging
     assert_offense <<~RUBY
       if Rails.env.staging?; end
-         ^^^^^^^^^^^^^^^^^^ Prefer using `Netlify.env`` instead of `Rails.env` to check the environment
+         ^^^^^^^^^^^^^^^^^^ Prefer using `Netlify.env` instead of `Rails.env` to check the environment
     RUBY
   end
 

--- a/test/rubocop/cop/netlify/rails_env_check_test.rb
+++ b/test/rubocop/cop/netlify/rails_env_check_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RailsEnvCheckTest < Minitest::Test
+  def test_offense_with_rails_production
+    assert_offense <<~RUBY
+      if Rails.env.production?; end
+         ^^^^^^^^^^^^^^^^^^^^^ Prefer using `Netlify.env`` instead of `Rails.env` to check the environment
+    RUBY
+  end
+
+  def test_offense_with_rails_staging
+    assert_offense <<~RUBY
+      if Rails.env.staging?; end
+         ^^^^^^^^^^^^^^^^^^ Prefer using `Netlify.env`` instead of `Rails.env` to check the environment
+    RUBY
+  end
+
+  def test_does_not_registers_offense_reading
+    assert_no_offenses <<~RUBY
+        if Rails.env.test?; end
+    RUBY
+  end
+end


### PR DESCRIPTION
**Summary**
What the title says.

This is only enforcing for `production?` and `staging?`, since that's where we can get ourselves into trouble. And we have legitimate usage of `Rails.env.test?` to implement `Netlify.env`. But we could choose to add it an then just add and disable the cop for that line. cc @phedinkus